### PR TITLE
fix Discord link in sidebar

### DIFF
--- a/components/System-Tray.vue
+++ b/components/System-Tray.vue
@@ -33,7 +33,7 @@ export default {
       {
         icon: 'mdi-discord',
         title: 'Discord',
-        to: 'https://discord.gg/ZUqgA9M',
+        to: 'https://discord.gg/vBb7D9a',
       },
     ],
   }),


### PR DESCRIPTION
sidebar link didn't work, the one in the body text does